### PR TITLE
Making request dependency version flexible to allow for v2.69.0 or greater minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.11.1",
     "moment": "2.13.0",
     "node-uuid": "1.4.7",
-    "request": "2.72.0"
+    "request": "^2.69.0"
   },
   "devDependencies": {
     "faker": "^3.1.0",


### PR DESCRIPTION
Newer versions seem to have memory leaks with node 4