### PR TITLE
fixed failing tests

### DIFF
--- a/lib/perimeterx.js
+++ b/lib/perimeterx.js
@@ -117,6 +117,7 @@ function pxPass(pxCtx) {
         'risk_rtt': pxCtx.riskRtt,
         'module_version': PxConfig.conf.MODULE_VERSION
     };
+    pxLogger.debug('sending page requested activity');
     pxClient.sendToPerimeterX('page_requested', details, pxCtx);
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -63,14 +63,14 @@ describe('PX Configurations - pxconfig.js', () => {
         done();
     });
 
-    it('blockHandler function should be overridden', (done) => {
-        params.blockHandler = function () {
+    it('requestHandler function should be overridden', (done) => {
+        params.customRequestHandler = function () {
             return 'Blocked';
         };
 
         pxconfig.init(params);
         const conf = pxconfig.conf;
-        conf.BLOCK_HANDLER().should.be.exactly('Blocked');
+        conf.CUSTOM_REQUEST_HANDLER().should.be.exactly('Blocked');
         done();
     });
 


### PR DESCRIPTION
1) added a debug output for sending page requested activity
2) renamed blockHandler test to use the new customRequestHandler