### PR TITLE
Fix for unused blockHandler config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ function customBlockHandler(req, res, next)
     /* user defined logic comes here */
 }
 
-const pxConfig = {
-    blockHandler: customBlockHandler
-}
+perimeterx.setBlockHandler(customBlockHandler);
 ```      
 
 ###### Examples
@@ -197,9 +195,7 @@ function customBlockHandler(req, res, next) {
     res.write(html);
     res.end();
 }
-const pxConfig = {
-    blockHandler: customBlockHandler
-}
+perimeterx.setBlockHandler(customBlockHandler);
 ```
 
 **No Blocking, Monitor Only**
@@ -213,10 +209,8 @@ function customBlockHandler(req, res, next) {
 
     return next()
 }
+perimeterx.setBlockHandler(customBlockHandler);
 
-const pxConfig = {
-    blockHandler: customBlockHandler
-}
 ```
 
 #### <a name="captcha-support"></a>Select CAPTCHA provider

--- a/lib/perimeterx.js
+++ b/lib/perimeterx.js
@@ -4,6 +4,7 @@ const PxExpressClient = require('./pxclient');
 const PxEnforcer = require('perimeterx-node-core').PxEnforcer;
 const cookieParser = require('cookie-parser');
 let enforcer;
+let blockHandler;
 
 /**
  * PerimeterX (http://www.perimeterx.com) NodeJS-Express SDK
@@ -12,6 +13,7 @@ let enforcer;
 module.exports.init = initPXModule;
 module.exports.middleware = pxMiddleware;
 module.exports.enforcer = () => {return enforcer};
+module.exports.setBlockHandler = setBlockHandler;
 
 /**
  * initPXModule - Initialize PerimeterX middleware.
@@ -19,7 +21,7 @@ module.exports.enforcer = () => {return enforcer};
  * @param {object} params - Configurations object to extend and overwrite the default settings.
  *
  */
-function initPXModule(params) {
+function initPXModule(params, blockHandler) {
     params.moduleVersion = MODULE_VERSION;
     let pxClient = new PxExpressClient();
     enforcer = new PxEnforcer(params, pxClient);
@@ -40,6 +42,23 @@ function parseCookies(req, res) {
     });
 }
 
+
+/**
+ * setBlockHandler - Sets a custom handler to use if the request is blocked.
+ *
+ * @param {Function} bh - The function to call if a request is blocked.
+ */
+function setBlockHandler(bh) {
+    blockHandler = bh;
+}
+
+/**
+ * getBlockHandler - Gets the custom handler to use if the request is blocked.
+ */
+function getBlockHandler(bh) {
+    return typeof blockHandler === "function" ? blockHandler : false;
+}
+
 /**
  * pxMiddleware - middleware wrapper to score verification.
  *
@@ -54,16 +73,27 @@ function pxMiddleware(req, res, next) {
                 res.send(err);
             }
             if (response) { //block
-                res.status(response.status);
-                if (response.header) {
-                    res.setHeader(response.header.key, response.header.value);
-                }
-                if (response.headers) {
-                    for (let header in response.headers) {
-                        res.setHeader(header, response.headers[header]);
+
+                req.block_score = response.block_score;
+                req.block_uuid  = response.block_uuid;
+
+                let bh = getBlockHandler();
+                if(bh) {
+                    //Custom block handler
+                    bh(req, res, next);
+                } else {
+                    //Default response
+                    res.status(response.status);
+                    if (response.header) {
+                        res.setHeader(response.header.key, response.header.value);
                     }
+                    if (response.headers) {
+                        for (let header in response.headers) {
+                            res.setHeader(header, response.headers[header]);
+                        }
+                    }
+                    res.send(response.body);
                 }
-                res.send(response.body);
             } else { //pass
                 next();
             }


### PR DESCRIPTION
This references [issue #19](https://github.com/PerimeterX/perimeterx-node-core/issues/19) in the perimeterx-node-core, where the blockHandler is unused and does not fire on callback.

This commit adds a handler so that the blockHandler is set outside of the config (since the blockHandler is not needed in the node-core, and node-express forwards the config directly to the node-core) and will fire instead of the default template if a request is blocked.