### PR TITLE
[UPDATE] perimeterx-node-core dependency (#82)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "lts/*"
   - "12"
-  - "11"
+  - "10"
   - "8"
 
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.2.0] - 2019-05-24
+### Added
+- send telemetry by command
+### Fixed
+- timeout error handling for api calls
+
 ## [6.1.1] - 2019-05-02
 ### Fixed
 - pxConfig setting for proxy

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [PerimeterX](http://www.perimeterx.com) Express.js Middleware
 =============================================================
 
-> Latest stable version: [v6.1.1](https://www.npmjs.com/package/perimeterx-node-express)
+> Latest stable version: [v6.2.0](https://www.npmjs.com/package/perimeterx-node-express)
 
 Table of Contents
 -----------------

--- a/lib/pxenforcer.js
+++ b/lib/pxenforcer.js
@@ -1,4 +1,4 @@
-const MODULE_VERSION = 'NodeJS Module v6.1.1';
+const MODULE_VERSION = 'NodeJS Module v6.2.0';
 const PxExpressClient = require('./pxclient');
 const PxEnforcer = require('perimeterx-node-core').PxEnforcer;
 const cookieParser = require('cookie-parser');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perimeterx-node-express",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "PerimeterX Express.js middleware to monitor and block traffic according to PerimeterX risk score",
   "main": "index.js",
   "directories": {
@@ -31,7 +31,7 @@
   "dependencies": {
     "cookie-parser": "^1.4.1",
     "moment": "^2.19.3",
-    "perimeterx-node-core": "~2.1.1"
+    "perimeterx-node-core": "^2.2.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
[FIX] api calls timeout error handling (perimeterx-node-core dependency update)
[CHANGE] node 11 to 10 since it became EOL
[VERSION] updated to 6.2.0