### PR TITLE
Release v7.2.0 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.2.0] - 2022-04-11
+
+### Added
+
+- New block page implementation
+- Support for dynamic cookie signing with IP (requires PXHD)
+- Send PX cookie over risk_api on sensitive routes
+
 ## [7.1.1] - 2022-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # [PerimeterX](http://www.perimeterx.com) Express.js Middleware
 
-> Latest stable version: [v7.1.1](https://www.npmjs.com/package/perimeterx-node-express)
+> Latest stable version: [v7.2.0](https://www.npmjs.com/package/perimeterx-node-express)
 
 ## Table of Contents
 

--- a/lib/pxenforcer.js
+++ b/lib/pxenforcer.js
@@ -4,7 +4,7 @@ const { PxEnforcer, PxCdFirstParty } = require('perimeterx-node-core');
 const PxExpressClient = require('./pxclient');
 const PxCdEnforcer = require('./pxcdenforcer');
 
-const MODULE_VERSION = 'NodeJS Module v7.1.1';
+const MODULE_VERSION = 'NodeJS Module v7.2.0';
 const MILLISECONDS_IN_MINUTE = 60000;
 
 function parseCookies(req, res) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "perimeterx-node-express",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "description": "PerimeterX Express.js middleware to monitor and block traffic according to PerimeterX risk score",
     "main": "index.js",
     "directories": {
@@ -30,7 +30,7 @@
     "homepage": "https://github.com/PerimeterX/perimeterx-node-express#readme",
     "dependencies": {
         "cookie-parser": "^1.4.1",
-        "perimeterx-node-core": "^3.2.0",
+        "perimeterx-node-core": "^3.3.2",
         "axios": "^0.21.1"
     },
     "devDependencies": {

--- a/px_metadata.json
+++ b/px_metadata.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.1.1",
+    "version": "7.2.0",
     "supported_features": [
         "additional_activity_handler",
         "advanced_blocking_response",


### PR DESCRIPTION
Updated Node-Core version to 3.3.2 (with the new block page).